### PR TITLE
pygatt: use handle in place of uuid

### DIFF
--- a/trionesControl/trionesControl.py
+++ b/trionesControl/trionesControl.py
@@ -24,7 +24,7 @@ def connect(MAC, reset_on_start=True):
         adapter.start(reset_on_start=reset_on_start)
         device = adapter.connect(MAC)
     except pygatt.exceptions.NotConnectedError:
-        raise pygatt.exceptions.NotConnectedError("Device nor connected!")
+        raise pygatt.exceptions.NotConnectedError("Device not connected!")
     log.info("Device connected")
     return device
 
@@ -32,7 +32,7 @@ def disconnect(device):
     try:
         device.disconnect()
     except pygatt.exceptions.NotConnectedError:
-        raise pygatt.exceptions.NotConnectedError("Device nor connected!")
+        raise pygatt.exceptions.NotConnectedError("Device not connected!")
     log.info("Device disconnected")
 
 def powerOn(device, wait_for_response=False):
@@ -45,7 +45,7 @@ def powerOn(device, wait_for_response=False):
     try:
         device.char_write_handle(MAIN_CHARACTERISTIC_HANDLE, b'\xcc\x23\x33', wait_for_response=wait_for_response)
     except pygatt.exceptions.NotConnectedError:
-        raise pygatt.exceptions.NotConnectedError("Device nor connected!")
+        raise pygatt.exceptions.NotConnectedError("Device not connected!")
     log.info("Device powered on")
 
 def powerOff(device, wait_for_response=False):
@@ -58,7 +58,7 @@ def powerOff(device, wait_for_response=False):
     try:
         device.char_write_handle(MAIN_CHARACTERISTIC_HANDLE, b'\xcc\x24\x33', wait_for_response=wait_for_response)
     except pygatt.exceptions.NotConnectedError:
-        raise pygatt.exceptions.NotConnectedError("Device nor connected!")
+        raise pygatt.exceptions.NotConnectedError("Device not connected!")
     log.info("Device powered off")
 
 def setRGB(r: int, g: int, b: int, device, wait_for_response=False):
@@ -86,7 +86,7 @@ def setRGB(r: int, g: int, b: int, device, wait_for_response=False):
     try:
         device.char_write_handle(MAIN_CHARACTERISTIC_HANDLE, payload, wait_for_response=wait_for_response)
     except pygatt.exceptions.NotConnectedError:
-        raise pygatt.exceptions.NotConnectedError("Device nor connected!")
+        raise pygatt.exceptions.NotConnectedError("Device not connected!")
     log.info("RGB set -- R: %d, G: %d, B: %d", r, g, b)
 
 def setWhite(intensity: int, device, wait_for_response=False):
@@ -109,7 +109,7 @@ def setWhite(intensity: int, device, wait_for_response=False):
     try:
         device.char_write_handle(MAIN_CHARACTERISTIC_HANDLE, payload, wait_for_response=wait_for_response)
     except pygatt.exceptions.NotConnectedError:
-        raise pygatt.exceptions.NotConnectedError("Device nor connected!")
+        raise pygatt.exceptions.NotConnectedError("Device not connected!")
     log.info("White color set -- Intensity: %d", intensity)
 
 def setBuiltIn(mode: int, speed: int, device, wait_for_response=False):
@@ -131,6 +131,6 @@ def setBuiltIn(mode: int, speed: int, device, wait_for_response=False):
     try:
         device.char_write_handle(MAIN_CHARACTERISTIC_HANDLE, payload, wait_for_response=wait_for_response)
     except pygatt.exceptions.NotConnectedError:
-        raise pygatt.exceptions.NotConnectedError("Device nor connected!")
+        raise pygatt.exceptions.NotConnectedError("Device not connected!")
     log.info("Default mode %d set -- Speed %d", mode, speed)
 

--- a/trionesControl/trionesControl.py
+++ b/trionesControl/trionesControl.py
@@ -2,7 +2,7 @@ import pygatt
 import logging
 import pygatt.exceptions 
 
-MAIN_CHARACTERISTIC_UUID = "0000ffd9-0000-1000-8000-00805f9b34fb"
+MAIN_CHARACTERISTIC_HANDLE = 0x0007
 
 log = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ def powerOn(device, wait_for_response=False):
     """
 
     try:
-        device.char_write(MAIN_CHARACTERISTIC_UUID, b'\xcc\x23\x33', wait_for_response=wait_for_response)
+        device.char_write_handle(MAIN_CHARACTERISTIC_HANDLE, b'\xcc\x23\x33', wait_for_response=wait_for_response)
     except pygatt.exceptions.NotConnectedError:
         raise pygatt.exceptions.NotConnectedError("Device nor connected!")
     log.info("Device powered on")
@@ -56,7 +56,7 @@ def powerOff(device, wait_for_response=False):
     """
 
     try:
-        device.char_write(MAIN_CHARACTERISTIC_UUID, b'\xcc\x24\x33', wait_for_response=wait_for_response)
+        device.char_write_handle(MAIN_CHARACTERISTIC_HANDLE, b'\xcc\x24\x33', wait_for_response=wait_for_response)
     except pygatt.exceptions.NotConnectedError:
         raise pygatt.exceptions.NotConnectedError("Device nor connected!")
     log.info("Device powered off")
@@ -84,7 +84,7 @@ def setRGB(r: int, g: int, b: int, device, wait_for_response=False):
     payload.append(0xF0)
     payload.append(0xAA)
     try:
-        device.char_write(MAIN_CHARACTERISTIC_UUID, payload, wait_for_response=wait_for_response)
+        device.char_write_handle(MAIN_CHARACTERISTIC_HANDLE, payload, wait_for_response=wait_for_response)
     except pygatt.exceptions.NotConnectedError:
         raise pygatt.exceptions.NotConnectedError("Device nor connected!")
     log.info("RGB set -- R: %d, G: %d, B: %d", r, g, b)
@@ -107,7 +107,7 @@ def setWhite(intensity: int, device, wait_for_response=False):
     payload.append(0x0F)
     payload.append(0xAA)
     try:
-        device.char_write(MAIN_CHARACTERISTIC_UUID, payload, wait_for_response=wait_for_response)
+        device.char_write_handle(MAIN_CHARACTERISTIC_HANDLE, payload, wait_for_response=wait_for_response)
     except pygatt.exceptions.NotConnectedError:
         raise pygatt.exceptions.NotConnectedError("Device nor connected!")
     log.info("White color set -- Intensity: %d", intensity)
@@ -129,7 +129,7 @@ def setBuiltIn(mode: int, speed: int, device, wait_for_response=False):
     payload.append(speed)
     payload.append(0x44)
     try:
-        device.char_write(MAIN_CHARACTERISTIC_UUID, payload, wait_for_response=wait_for_response)
+        device.char_write_handle(MAIN_CHARACTERISTIC_HANDLE, payload, wait_for_response=wait_for_response)
     except pygatt.exceptions.NotConnectedError:
         raise pygatt.exceptions.NotConnectedError("Device nor connected!")
     log.info("Default mode %d set -- Speed %d", mode, speed)


### PR DESCRIPTION
Hey,
I couldn't get this to work with my own triones bulbs. After some tinkering, I discovered that the problem was that `gatttool` got stuck when asking for `characteristics`. Unfortunately, `device.char_write(UUID, [...])` must call `characteristics` to get the handle associated with the UUID in order to finally call `device.char_write_handle(handle, [...])`.

This patch uses the handle (`0x0007`) directly, obviating the need for the call to `characteristics` and thus fixing the problem.

I have no idea whether the handle `0x0007` is constant or not. If it isn't, then the patch must be made in pygatt (using `char-desc` instead of `characteristics` to go from UUID to handle).

The PR also includes a commit that fixes a typo.

Thanks,
Alessandro